### PR TITLE
[FEAT] 스플래시, 홈 화면 구현 완료

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <uses-permission android:name="android.permission.INTERNET" />
+
     <application
         android:name=".App"
         android:allowBackup="true"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -15,18 +15,13 @@
         android:theme="@style/Theme.GumiLifeProject"
         tools:targetApi="31">
         <activity
-            android:name=".ui.splash.SplashActivity"
-            android:exported="true" >
+            android:name=".ui.main.MainActivity"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
-        </activity>
-        <activity
-            android:name=".ui.main.MainActivity"
-            android:exported="true">
-
         </activity>
     </application>
 

--- a/app/src/main/java/com/ssafy/gumi_life_project/data/model/ErrorResponse.kt
+++ b/app/src/main/java/com/ssafy/gumi_life_project/data/model/ErrorResponse.kt
@@ -1,5 +1,5 @@
 package com.ssafy.gumi_life_project.data.model
 
 data class ErrorResponse(
-    val description : String?
+    val description: String?
 )

--- a/app/src/main/java/com/ssafy/gumi_life_project/data/model/ErrorResponse.kt
+++ b/app/src/main/java/com/ssafy/gumi_life_project/data/model/ErrorResponse.kt
@@ -1,0 +1,5 @@
+package com.ssafy.gumi_life_project.data.model
+
+data class ErrorResponse(
+    val description : String?
+)

--- a/app/src/main/java/com/ssafy/gumi_life_project/data/model/Tip.kt
+++ b/app/src/main/java/com/ssafy/gumi_life_project/data/model/Tip.kt
@@ -1,0 +1,8 @@
+package com.ssafy.gumi_life_project.data.model
+
+data class Tip(
+    val id : Int,
+    val subject : String,
+    val discription : String,
+    val good : Int
+)

--- a/app/src/main/java/com/ssafy/gumi_life_project/data/model/Tip.kt
+++ b/app/src/main/java/com/ssafy/gumi_life_project/data/model/Tip.kt
@@ -1,8 +1,13 @@
 package com.ssafy.gumi_life_project.data.model
 
+import com.google.gson.annotations.SerializedName
+
 data class Tip(
     val id : Int,
     val subject : String,
-    val discription : String,
+    @SerializedName("discription")
+    val description : String,
     val good : Int
-)
+) {
+    constructor() : this(0, "", "", 0)
+}

--- a/app/src/main/java/com/ssafy/gumi_life_project/data/model/Tip.kt
+++ b/app/src/main/java/com/ssafy/gumi_life_project/data/model/Tip.kt
@@ -3,11 +3,11 @@ package com.ssafy.gumi_life_project.data.model
 import com.google.gson.annotations.SerializedName
 
 data class Tip(
-    val id : Int,
-    val subject : String,
+    val id: Int,
+    val subject: String,
     @SerializedName("discription")
-    val description : String,
-    val good : Int
+    val description: String,
+    val good: Int
 ) {
     constructor() : this(0, "", "", 0)
 }

--- a/app/src/main/java/com/ssafy/gumi_life_project/data/model/Weather.kt
+++ b/app/src/main/java/com/ssafy/gumi_life_project/data/model/Weather.kt
@@ -1,0 +1,14 @@
+package com.ssafy.gumi_life_project.data.model
+
+import com.google.gson.annotations.SerializedName
+
+data class Weather(
+    @SerializedName("온도") val temperature: String,
+    @SerializedName("강수 형태") val precipitationType: String,
+    @SerializedName("1시간 강수량") val hourlyPrecipitation: String
+)
+
+data class WeatherResponse(
+    @SerializedName("data") val data: Weather,
+    @SerializedName("message") val message: String
+)

--- a/app/src/main/java/com/ssafy/gumi_life_project/data/remote/ApiService.kt
+++ b/app/src/main/java/com/ssafy/gumi_life_project/data/remote/ApiService.kt
@@ -8,8 +8,8 @@ import retrofit2.http.GET
 
 interface ApiService {
     @GET("/tip/list")
-    suspend fun getAllTipList() : NetworkResponse<List<Tip>, ErrorResponse>
+    suspend fun getAllTipList(): NetworkResponse<List<Tip>, ErrorResponse>
 
     @GET("/weather/")
-    suspend fun getNowWeather() : NetworkResponse<WeatherResponse, ErrorResponse>
+    suspend fun getNowWeather(): NetworkResponse<WeatherResponse, ErrorResponse>
 }

--- a/app/src/main/java/com/ssafy/gumi_life_project/data/remote/ApiService.kt
+++ b/app/src/main/java/com/ssafy/gumi_life_project/data/remote/ApiService.kt
@@ -2,10 +2,14 @@ package com.ssafy.gumi_life_project.data.remote
 
 import com.ssafy.gumi_life_project.data.model.ErrorResponse
 import com.ssafy.gumi_life_project.data.model.Tip
+import com.ssafy.gumi_life_project.data.model.WeatherResponse
 import com.ssafy.gumi_life_project.util.network.NetworkResponse
 import retrofit2.http.GET
 
 interface ApiService {
     @GET("/tip/list")
     suspend fun getAllTipList() : NetworkResponse<List<Tip>, ErrorResponse>
+
+    @GET("/weather/")
+    suspend fun getNowWeather() : NetworkResponse<WeatherResponse, ErrorResponse>
 }

--- a/app/src/main/java/com/ssafy/gumi_life_project/data/remote/ApiService.kt
+++ b/app/src/main/java/com/ssafy/gumi_life_project/data/remote/ApiService.kt
@@ -1,4 +1,11 @@
 package com.ssafy.gumi_life_project.data.remote
 
+import com.ssafy.gumi_life_project.data.model.ErrorResponse
+import com.ssafy.gumi_life_project.data.model.Tip
+import com.ssafy.gumi_life_project.util.network.NetworkResponse
+import retrofit2.http.GET
+
 interface ApiService {
+    @GET("/tip/list")
+    suspend fun getAllTipList() : NetworkResponse<List<Tip>, ErrorResponse>
 }

--- a/app/src/main/java/com/ssafy/gumi_life_project/data/repository/home/HomeRepository.kt
+++ b/app/src/main/java/com/ssafy/gumi_life_project/data/repository/home/HomeRepository.kt
@@ -1,4 +1,9 @@
 package com.ssafy.gumi_life_project.data.repository.home
 
+import com.ssafy.gumi_life_project.data.model.ErrorResponse
+import com.ssafy.gumi_life_project.data.model.Tip
+import com.ssafy.gumi_life_project.util.network.NetworkResponse
+
 interface HomeRepository {
+    suspend fun getAllTipList() : NetworkResponse<List<Tip>, ErrorResponse>
 }

--- a/app/src/main/java/com/ssafy/gumi_life_project/data/repository/home/HomeRepository.kt
+++ b/app/src/main/java/com/ssafy/gumi_life_project/data/repository/home/HomeRepository.kt
@@ -2,8 +2,11 @@ package com.ssafy.gumi_life_project.data.repository.home
 
 import com.ssafy.gumi_life_project.data.model.ErrorResponse
 import com.ssafy.gumi_life_project.data.model.Tip
+import com.ssafy.gumi_life_project.data.model.WeatherResponse
 import com.ssafy.gumi_life_project.util.network.NetworkResponse
 
 interface HomeRepository {
     suspend fun getAllTipList() : NetworkResponse<List<Tip>, ErrorResponse>
+
+    suspend fun getNowWeather() : NetworkResponse<WeatherResponse, ErrorResponse>
 }

--- a/app/src/main/java/com/ssafy/gumi_life_project/data/repository/home/HomeRepository.kt
+++ b/app/src/main/java/com/ssafy/gumi_life_project/data/repository/home/HomeRepository.kt
@@ -6,7 +6,4 @@ import com.ssafy.gumi_life_project.data.model.WeatherResponse
 import com.ssafy.gumi_life_project.util.network.NetworkResponse
 
 interface HomeRepository {
-    suspend fun getAllTipList() : NetworkResponse<List<Tip>, ErrorResponse>
-
-    suspend fun getNowWeather() : NetworkResponse<WeatherResponse, ErrorResponse>
 }

--- a/app/src/main/java/com/ssafy/gumi_life_project/data/repository/home/HomeRepositoryImpl.kt
+++ b/app/src/main/java/com/ssafy/gumi_life_project/data/repository/home/HomeRepositoryImpl.kt
@@ -2,6 +2,7 @@ package com.ssafy.gumi_life_project.data.repository.home
 
 import com.ssafy.gumi_life_project.data.model.ErrorResponse
 import com.ssafy.gumi_life_project.data.model.Tip
+import com.ssafy.gumi_life_project.data.model.WeatherResponse
 import com.ssafy.gumi_life_project.data.remote.ApiService
 import com.ssafy.gumi_life_project.util.network.NetworkResponse
 import javax.inject.Inject
@@ -11,6 +12,10 @@ class HomeRepositoryImpl @Inject constructor(
 ) : HomeRepository {
     override suspend fun getAllTipList(): NetworkResponse<List<Tip>, ErrorResponse> {
         return apiService.getAllTipList()
+    }
+
+    override suspend fun getNowWeather(): NetworkResponse<WeatherResponse, ErrorResponse> {
+        return apiService.getNowWeather()
     }
 
 }

--- a/app/src/main/java/com/ssafy/gumi_life_project/data/repository/home/HomeRepositoryImpl.kt
+++ b/app/src/main/java/com/ssafy/gumi_life_project/data/repository/home/HomeRepositoryImpl.kt
@@ -10,12 +10,4 @@ import javax.inject.Inject
 class HomeRepositoryImpl @Inject constructor(
     private val apiService: ApiService
 ) : HomeRepository {
-    override suspend fun getAllTipList(): NetworkResponse<List<Tip>, ErrorResponse> {
-        return apiService.getAllTipList()
-    }
-
-    override suspend fun getNowWeather(): NetworkResponse<WeatherResponse, ErrorResponse> {
-        return apiService.getNowWeather()
-    }
-
 }

--- a/app/src/main/java/com/ssafy/gumi_life_project/data/repository/home/HomeRepositoryImpl.kt
+++ b/app/src/main/java/com/ssafy/gumi_life_project/data/repository/home/HomeRepositoryImpl.kt
@@ -1,10 +1,16 @@
 package com.ssafy.gumi_life_project.data.repository.home
 
+import com.ssafy.gumi_life_project.data.model.ErrorResponse
+import com.ssafy.gumi_life_project.data.model.Tip
 import com.ssafy.gumi_life_project.data.remote.ApiService
+import com.ssafy.gumi_life_project.util.network.NetworkResponse
 import javax.inject.Inject
 
 class HomeRepositoryImpl @Inject constructor(
     private val apiService: ApiService
 ) : HomeRepository {
+    override suspend fun getAllTipList(): NetworkResponse<List<Tip>, ErrorResponse> {
+        return apiService.getAllTipList()
+    }
 
 }

--- a/app/src/main/java/com/ssafy/gumi_life_project/data/repository/main/MainRepository.kt
+++ b/app/src/main/java/com/ssafy/gumi_life_project/data/repository/main/MainRepository.kt
@@ -1,4 +1,12 @@
 package com.ssafy.gumi_life_project.data.repository.main
 
+import com.ssafy.gumi_life_project.data.model.ErrorResponse
+import com.ssafy.gumi_life_project.data.model.Tip
+import com.ssafy.gumi_life_project.data.model.WeatherResponse
+import com.ssafy.gumi_life_project.util.network.NetworkResponse
+
 interface MainRepository {
+    suspend fun getAllTipList() : NetworkResponse<List<Tip>, ErrorResponse>
+
+    suspend fun getNowWeather() : NetworkResponse<WeatherResponse, ErrorResponse>
 }

--- a/app/src/main/java/com/ssafy/gumi_life_project/data/repository/main/MainRepository.kt
+++ b/app/src/main/java/com/ssafy/gumi_life_project/data/repository/main/MainRepository.kt
@@ -6,7 +6,7 @@ import com.ssafy.gumi_life_project.data.model.WeatherResponse
 import com.ssafy.gumi_life_project.util.network.NetworkResponse
 
 interface MainRepository {
-    suspend fun getAllTipList() : NetworkResponse<List<Tip>, ErrorResponse>
+    suspend fun getAllTipList(): NetworkResponse<List<Tip>, ErrorResponse>
 
-    suspend fun getNowWeather() : NetworkResponse<WeatherResponse, ErrorResponse>
+    suspend fun getNowWeather(): NetworkResponse<WeatherResponse, ErrorResponse>
 }

--- a/app/src/main/java/com/ssafy/gumi_life_project/data/repository/main/MainRepositoryImpl.kt
+++ b/app/src/main/java/com/ssafy/gumi_life_project/data/repository/main/MainRepositoryImpl.kt
@@ -1,10 +1,21 @@
 package com.ssafy.gumi_life_project.data.repository.main
 
+import com.ssafy.gumi_life_project.data.model.ErrorResponse
+import com.ssafy.gumi_life_project.data.model.Tip
+import com.ssafy.gumi_life_project.data.model.WeatherResponse
 import com.ssafy.gumi_life_project.data.remote.ApiService
+import com.ssafy.gumi_life_project.util.network.NetworkResponse
 import javax.inject.Inject
 
 class MainRepositoryImpl @Inject constructor(
     private val apiService: ApiService
 ) : MainRepository {
+    override suspend fun getAllTipList(): NetworkResponse<List<Tip>, ErrorResponse> {
+        return apiService.getAllTipList()
+    }
+
+    override suspend fun getNowWeather(): NetworkResponse<WeatherResponse, ErrorResponse> {
+        return apiService.getNowWeather()
+    }
 
 }

--- a/app/src/main/java/com/ssafy/gumi_life_project/di/module/ApiModule.kt
+++ b/app/src/main/java/com/ssafy/gumi_life_project/di/module/ApiModule.kt
@@ -16,7 +16,7 @@ import javax.inject.Singleton
 @InstallIn(SingletonComponent::class)
 object ApiModule {
 
-    private const val baseUrl = "http://127.0.0.1:9999"
+    private const val baseUrl = "https://gumiinsider-ea09851d1f47.herokuapp.com/"
 
     @Provides
     @Singleton

--- a/app/src/main/java/com/ssafy/gumi_life_project/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/ssafy/gumi_life_project/ui/home/HomeFragment.kt
@@ -1,5 +1,6 @@
 package com.ssafy.gumi_life_project.ui.home
 
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import androidx.fragment.app.viewModels
@@ -9,6 +10,7 @@ import com.ssafy.gumi_life_project.ui.home.crosswalk.CrossWorkBottomSheet
 import com.ssafy.gumi_life_project.util.template.BaseFragment
 import dagger.hilt.android.AndroidEntryPoint
 
+private const val TAG = "HomeFragment_구미"
 @AndroidEntryPoint
 class HomeFragment : BaseFragment<FragmentHomeBinding>(
     R.layout.fragment_home
@@ -49,6 +51,13 @@ class HomeFragment : BaseFragment<FragmentHomeBinding>(
                     bottomSheetDialogFragment.show(childFragmentManager, "CrossWorkBottomSheet")
                 }
             }
+
+            tip.observe(viewLifecycleOwner) { event ->
+                event.getContentIfNotHandled()?.let {
+                    Log.d(TAG, "observeData: $it")
+                }
+            }
+
         }
     }
 }

--- a/app/src/main/java/com/ssafy/gumi_life_project/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/ssafy/gumi_life_project/ui/home/HomeFragment.kt
@@ -29,6 +29,7 @@ class HomeFragment : BaseFragment<FragmentHomeBinding>(
 
     override fun init() {
         observeData()
+        viewModel.getNowWeather()
     }
 
     private fun observeData() {
@@ -56,6 +57,13 @@ class HomeFragment : BaseFragment<FragmentHomeBinding>(
                 event.getContentIfNotHandled()?.let {
                     Log.d(TAG, "observeData: $it")
                 }
+            }
+            
+            weather.observe(viewLifecycleOwner) { event ->
+                event.getContentIfNotHandled()?.let {
+                    Log.d(TAG, "observeData: $it")
+                }
+                
             }
 
         }

--- a/app/src/main/java/com/ssafy/gumi_life_project/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/ssafy/gumi_life_project/ui/home/HomeFragment.kt
@@ -1,14 +1,18 @@
 package com.ssafy.gumi_life_project.ui.home
 
+import android.os.Bundle
 import android.util.Log
 import android.view.LayoutInflater
+import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.viewModels
 import com.ssafy.gumi_life_project.R
+import com.ssafy.gumi_life_project.data.model.Tip
 import com.ssafy.gumi_life_project.databinding.FragmentHomeBinding
 import com.ssafy.gumi_life_project.ui.home.crosswalk.CrossWorkBottomSheet
 import com.ssafy.gumi_life_project.util.template.BaseFragment
 import dagger.hilt.android.AndroidEntryPoint
+import kotlin.random.Random
 
 private const val TAG = "HomeFragment_구미"
 @AndroidEntryPoint
@@ -27,9 +31,14 @@ class HomeFragment : BaseFragment<FragmentHomeBinding>(
         }
     }
 
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        viewModel.getAllTipList()
+        viewModel.getNowWeather()
+    }
+
     override fun init() {
         observeData()
-        viewModel.getNowWeather()
     }
 
     private fun observeData() {
@@ -55,7 +64,14 @@ class HomeFragment : BaseFragment<FragmentHomeBinding>(
 
             tip.observe(viewLifecycleOwner) { event ->
                 event.getContentIfNotHandled()?.let {
-                    Log.d(TAG, "observeData: $it")
+                    val randomTip = getRandomTip(it)
+                    bindingNonNull.textviewTipContent.text = limitStringLength(randomTip.subject)
+
+                    bindingNonNull.linearlayoutTip.setOnClickListener {
+                        val bottomSheetDialogFragment = TipBottomSheet(randomTip.subject, randomTip.description)
+                        bottomSheetDialogFragment.show(childFragmentManager, "TipBottomSheet")
+                    }
+
                 }
             }
             
@@ -68,4 +84,13 @@ class HomeFragment : BaseFragment<FragmentHomeBinding>(
 
         }
     }
+
+    private fun getRandomTip(tips : List<Tip>) : Tip {
+        return if (tips.isNotEmpty()) tips[Random.nextInt(tips.size)] else Tip()
+    }
+
+    private fun limitStringLength(input: String, maxLength: Int = 23): String {
+        return if (input.length > maxLength) input.substring(0, maxLength) + "..." else input
+    }
+
 }

--- a/app/src/main/java/com/ssafy/gumi_life_project/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/ssafy/gumi_life_project/ui/home/HomeFragment.kt
@@ -1,9 +1,7 @@
 package com.ssafy.gumi_life_project.ui.home
 
-import android.os.Bundle
 import android.util.Log
 import android.view.LayoutInflater
-import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
@@ -17,6 +15,7 @@ import dagger.hilt.android.AndroidEntryPoint
 import kotlin.random.Random
 
 private const val TAG = "HomeFragment_구미"
+
 @AndroidEntryPoint
 class HomeFragment : BaseFragment<FragmentHomeBinding>(
     R.layout.fragment_home
@@ -68,7 +67,8 @@ class HomeFragment : BaseFragment<FragmentHomeBinding>(
                     bindingNonNull.textviewTipContent.text = limitStringLength(randomTip.subject)
 
                     bindingNonNull.linearlayoutTip.setOnClickListener {
-                        val bottomSheetDialogFragment = TipBottomSheet(randomTip.subject, randomTip.description)
+                        val bottomSheetDialogFragment =
+                            TipBottomSheet(randomTip.subject, randomTip.description)
                         bottomSheetDialogFragment.show(childFragmentManager, "TipBottomSheet")
                     }
 
@@ -87,7 +87,7 @@ class HomeFragment : BaseFragment<FragmentHomeBinding>(
         }
     }
 
-    private fun getRandomTip(tips : List<Tip>) : Tip {
+    private fun getRandomTip(tips: List<Tip>): Tip {
         return if (tips.isNotEmpty()) tips[Random.nextInt(tips.size)] else Tip()
     }
 

--- a/app/src/main/java/com/ssafy/gumi_life_project/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/ssafy/gumi_life_project/ui/home/HomeFragment.kt
@@ -5,11 +5,13 @@ import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
 import com.ssafy.gumi_life_project.R
 import com.ssafy.gumi_life_project.data.model.Tip
 import com.ssafy.gumi_life_project.databinding.FragmentHomeBinding
 import com.ssafy.gumi_life_project.ui.home.crosswalk.CrossWorkBottomSheet
+import com.ssafy.gumi_life_project.ui.main.MainViewModel
 import com.ssafy.gumi_life_project.util.template.BaseFragment
 import dagger.hilt.android.AndroidEntryPoint
 import kotlin.random.Random
@@ -20,6 +22,7 @@ class HomeFragment : BaseFragment<FragmentHomeBinding>(
     R.layout.fragment_home
 ) {
     private val viewModel by viewModels<HomeViewModel>()
+    private val activityViewModel by activityViewModels<MainViewModel>()
 
     override fun onCreateBinding(
         inflater: LayoutInflater,
@@ -28,13 +31,8 @@ class HomeFragment : BaseFragment<FragmentHomeBinding>(
         return FragmentHomeBinding.inflate(inflater, container, false).apply {
             lifecycleOwner = viewLifecycleOwner
             viewModel = this@HomeFragment.viewModel
+            mainViewModel = this@HomeFragment.activityViewModel
         }
-    }
-
-    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        super.onViewCreated(view, savedInstanceState)
-        viewModel.getAllTipList()
-        viewModel.getNowWeather()
     }
 
     override fun init() {
@@ -61,7 +59,9 @@ class HomeFragment : BaseFragment<FragmentHomeBinding>(
                     bottomSheetDialogFragment.show(childFragmentManager, "CrossWorkBottomSheet")
                 }
             }
+        }
 
+        with(activityViewModel) {
             tip.observe(viewLifecycleOwner) { event ->
                 event.getContentIfNotHandled()?.let {
                     val randomTip = getRandomTip(it)
@@ -74,7 +74,7 @@ class HomeFragment : BaseFragment<FragmentHomeBinding>(
 
                 }
             }
-            
+
             weather.observe(viewLifecycleOwner) { event ->
                 event.getContentIfNotHandled()?.let {
                     val weather = it.data
@@ -82,9 +82,8 @@ class HomeFragment : BaseFragment<FragmentHomeBinding>(
                     bindingNonNull.textviewTodayWeatherTemperature.text = weather.temperature + "º"
                     makeWeatherIcon(weather.precipitationType)
                 }
-                
-            }
 
+            }
         }
     }
 

--- a/app/src/main/java/com/ssafy/gumi_life_project/ui/home/HomeFragment.kt
+++ b/app/src/main/java/com/ssafy/gumi_life_project/ui/home/HomeFragment.kt
@@ -77,7 +77,10 @@ class HomeFragment : BaseFragment<FragmentHomeBinding>(
             
             weather.observe(viewLifecycleOwner) { event ->
                 event.getContentIfNotHandled()?.let {
+                    val weather = it.data
                     Log.d(TAG, "observeData: $it")
+                    bindingNonNull.textviewTodayWeatherTemperature.text = weather.temperature + "º"
+                    makeWeatherIcon(weather.precipitationType)
                 }
                 
             }
@@ -91,6 +94,14 @@ class HomeFragment : BaseFragment<FragmentHomeBinding>(
 
     private fun limitStringLength(input: String, maxLength: Int = 23): String {
         return if (input.length > maxLength) input.substring(0, maxLength) + "..." else input
+    }
+
+    private fun makeWeatherIcon(type: String) {
+        when (type) {
+            "없음" -> bindingNonNull.imageviewTodayWeatherImg.setImageResource(R.drawable.icon_sunny)
+            "비" -> bindingNonNull.imageviewTodayWeatherImg.setImageResource(R.drawable.icon_rainy)
+            "눈" -> bindingNonNull.imageviewTodayWeatherImg.setImageResource(R.drawable.icon_snow)
+        }
     }
 
 }

--- a/app/src/main/java/com/ssafy/gumi_life_project/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/ssafy/gumi_life_project/ui/home/HomeViewModel.kt
@@ -1,12 +1,17 @@
 package com.ssafy.gumi_life_project.ui.home
 
+import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.viewModelScope
 import com.ssafy.gumi_life_project.data.model.Event
 import com.ssafy.gumi_life_project.data.model.SignalLight
+import com.ssafy.gumi_life_project.data.model.Tip
 import com.ssafy.gumi_life_project.data.repository.home.HomeRepository
+import com.ssafy.gumi_life_project.util.network.NetworkResponse
 import com.ssafy.gumi_life_project.util.template.BaseViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
@@ -20,6 +25,32 @@ class HomeViewModel @Inject constructor(
     private val _showBottomSheetEvent = MutableLiveData<Event<SignalLight>>()
     val showBottomSheetEvent: LiveData<Event<SignalLight>> = _showBottomSheetEvent
 
+    private val _tip = MutableLiveData<Event<List<Tip>>>()
+    val tip: LiveData<Event<List<Tip>>> = _tip
+
+
+    fun getAllTipList() {
+        showProgress()
+        viewModelScope.launch {
+            val response = repository.getAllTipList()
+
+            val type = "정보 조회에"
+            when (response) {
+                is NetworkResponse.Success -> {
+                    _tip.value = Event(response.body)
+                }
+                is NetworkResponse.ApiError -> {
+                    postValueEvent(0, type)
+                }
+                is NetworkResponse.NetworkError -> {
+                    postValueEvent(1, type)
+                }
+                is NetworkResponse.UnknownError -> {
+                    postValueEvent(2, type)
+                }
+            }
+        }
+    }
 
     private fun postValueEvent(value: Int, type: String) {
         val msgArrayList = arrayOf(

--- a/app/src/main/java/com/ssafy/gumi_life_project/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/ssafy/gumi_life_project/ui/home/HomeViewModel.kt
@@ -1,18 +1,15 @@
 package com.ssafy.gumi_life_project.ui.home
 
-import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
-import androidx.lifecycle.viewModelScope
-import com.ssafy.gumi_life_project.data.model.*
+import com.ssafy.gumi_life_project.data.model.Event
+import com.ssafy.gumi_life_project.data.model.SignalLight
 import com.ssafy.gumi_life_project.data.repository.home.HomeRepository
-import com.ssafy.gumi_life_project.util.network.NetworkResponse
 import com.ssafy.gumi_life_project.util.template.BaseViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.launch
 import javax.inject.Inject
 
-private const val TAG = "HomeViewModel_구미"
+
 @HiltViewModel
 class HomeViewModel @Inject constructor(
     private val repository: HomeRepository

--- a/app/src/main/java/com/ssafy/gumi_life_project/ui/home/HomeViewModel.kt
+++ b/app/src/main/java/com/ssafy/gumi_life_project/ui/home/HomeViewModel.kt
@@ -24,63 +24,6 @@ class HomeViewModel @Inject constructor(
     private val _showBottomSheetEvent = MutableLiveData<Event<SignalLight>>()
     val showBottomSheetEvent: LiveData<Event<SignalLight>> = _showBottomSheetEvent
 
-    private val _tip = MutableLiveData<Event<List<Tip>>>()
-    val tip: LiveData<Event<List<Tip>>> = _tip
-    
-    private val _weather = MutableLiveData<Event<WeatherResponse>>()
-    val weather: LiveData<Event<WeatherResponse>> = _weather
-
-
-    fun getAllTipList() {
-        showProgress()
-        viewModelScope.launch {
-            val response = repository.getAllTipList()
-
-            val type = "정보 조회에"
-            when (response) {
-                is NetworkResponse.Success -> {
-                    _tip.value = Event(response.body)
-                }
-                is NetworkResponse.ApiError -> {
-                    postValueEvent(0, type)
-                }
-                is NetworkResponse.NetworkError -> {
-                    postValueEvent(1, type)
-                }
-                is NetworkResponse.UnknownError -> {
-                    postValueEvent(2, type)
-                }
-            }
-        }
-        hideProgress()
-    }
-    
-    fun getNowWeather() {
-        showProgress()
-        viewModelScope.launch {
-            val response = repository.getNowWeather()
-            Log.d(TAG, "getNowWeather: $response")
-
-            val type = "정보 조회에"
-            when (response) {
-                is NetworkResponse.Success -> {
-                    _weather.value = Event(response.body)
-                    Log.d(TAG, "getNowWeather: ${weather.value}")
-                }
-                is NetworkResponse.ApiError -> {
-                    postValueEvent(0, type)
-                }
-                is NetworkResponse.NetworkError -> {
-                    postValueEvent(1, type)
-                }
-                is NetworkResponse.UnknownError -> {
-                    postValueEvent(2, type)
-                }
-            }
-        }
-        hideProgress()
-    }
-
     private fun postValueEvent(value: Int, type: String) {
         val msgArrayList = arrayOf(
             "Api 오류 : $type 실패했습니다.",
@@ -98,4 +41,5 @@ class HomeViewModel @Inject constructor(
     fun onCrossWorkTimeViewClicked(signalLight: SignalLight) {
         _showBottomSheetEvent.value = Event(signalLight)
     }
+
 }

--- a/app/src/main/java/com/ssafy/gumi_life_project/ui/home/TipBottomSheet.kt
+++ b/app/src/main/java/com/ssafy/gumi_life_project/ui/home/TipBottomSheet.kt
@@ -9,8 +9,9 @@ import com.ssafy.gumi_life_project.R
 import com.ssafy.gumi_life_project.databinding.BottomSheetTipBinding
 
 
-class TipBottomSheet(private val subject: String?, private val description: String?) : BottomSheetDialogFragment(){
-    lateinit var binding : BottomSheetTipBinding
+class TipBottomSheet(private val subject: String?, private val description: String?) :
+    BottomSheetDialogFragment() {
+    lateinit var binding: BottomSheetTipBinding
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,

--- a/app/src/main/java/com/ssafy/gumi_life_project/ui/home/TipBottomSheet.kt
+++ b/app/src/main/java/com/ssafy/gumi_life_project/ui/home/TipBottomSheet.kt
@@ -1,0 +1,31 @@
+package com.ssafy.gumi_life_project.ui.home
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import com.google.android.material.bottomsheet.BottomSheetDialogFragment
+import com.ssafy.gumi_life_project.R
+import com.ssafy.gumi_life_project.databinding.BottomSheetTipBinding
+
+
+class TipBottomSheet(private val subject: String?, private val description: String?) : BottomSheetDialogFragment(){
+    lateinit var binding : BottomSheetTipBinding
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        binding = BottomSheetTipBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        binding.textviewTipSubject.text = subject
+        binding.textviewTipDescription.text = description
+    }
+
+    override fun getTheme(): Int = R.style.BottomSheetDialog
+}

--- a/app/src/main/java/com/ssafy/gumi_life_project/ui/main/MainActivity.kt
+++ b/app/src/main/java/com/ssafy/gumi_life_project/ui/main/MainActivity.kt
@@ -18,7 +18,8 @@ class MainActivity : BaseActivity<ActivityMainBinding>(R.layout.activity_main) {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        val navHostFragment = supportFragmentManager.findFragmentById(R.id.nav_host_fragment) as NavHostFragment
+        val navHostFragment =
+            supportFragmentManager.findFragmentById(R.id.nav_host_fragment) as NavHostFragment
         navController = navHostFragment.navController
         observeData()
     }

--- a/app/src/main/java/com/ssafy/gumi_life_project/ui/main/MainViewModel.kt
+++ b/app/src/main/java/com/ssafy/gumi_life_project/ui/main/MainViewModel.kt
@@ -1,13 +1,20 @@
 package com.ssafy.gumi_life_project.ui.main
 
+import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.viewModelScope
 import com.ssafy.gumi_life_project.data.model.Event
+import com.ssafy.gumi_life_project.data.model.Tip
+import com.ssafy.gumi_life_project.data.model.WeatherResponse
 import com.ssafy.gumi_life_project.data.repository.main.MainRepository
+import com.ssafy.gumi_life_project.util.network.NetworkResponse
 import com.ssafy.gumi_life_project.util.template.BaseViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
+private const val TAG = "MainViewModel_구미"
 @HiltViewModel
 class MainViewModel @Inject constructor(
     private val repository: MainRepository
@@ -15,6 +22,62 @@ class MainViewModel @Inject constructor(
 
     private val _msg = MutableLiveData<Event<String>>()
     val errorMsg : LiveData<Event<String>> = _msg
+
+    private val _tip = MutableLiveData<Event<List<Tip>>>()
+    val tip: LiveData<Event<List<Tip>>> = _tip
+
+    private val _weather = MutableLiveData<Event<WeatherResponse>>()
+    val weather: LiveData<Event<WeatherResponse>> = _weather
+
+    fun getAllTipList() {
+        showProgress()
+        viewModelScope.launch {
+            val response = repository.getAllTipList()
+
+            val type = "정보 조회에"
+            when (response) {
+                is NetworkResponse.Success -> {
+                    _tip.value = Event(response.body)
+                }
+                is NetworkResponse.ApiError -> {
+                    postValueEvent(0, type)
+                }
+                is NetworkResponse.NetworkError -> {
+                    postValueEvent(1, type)
+                }
+                is NetworkResponse.UnknownError -> {
+                    postValueEvent(2, type)
+                }
+            }
+        }
+        hideProgress()
+    }
+
+    fun getNowWeather() {
+        showProgress()
+        viewModelScope.launch {
+            val response = repository.getNowWeather()
+            Log.d(TAG, "getNowWeather: $response")
+
+            val type = "정보 조회에"
+            when (response) {
+                is NetworkResponse.Success -> {
+                    _weather.value = Event(response.body)
+                    Log.d(TAG, "getNowWeather: ${weather.value}")
+                }
+                is NetworkResponse.ApiError -> {
+                    postValueEvent(0, type)
+                }
+                is NetworkResponse.NetworkError -> {
+                    postValueEvent(1, type)
+                }
+                is NetworkResponse.UnknownError -> {
+                    postValueEvent(2, type)
+                }
+            }
+        }
+        hideProgress()
+    }
 
 
     private fun postValueEvent(value : Int, type: String) {

--- a/app/src/main/java/com/ssafy/gumi_life_project/ui/splash/SplashFragment.kt
+++ b/app/src/main/java/com/ssafy/gumi_life_project/ui/splash/SplashFragment.kt
@@ -1,17 +1,13 @@
 package com.ssafy.gumi_life_project.ui.splash
 
-import android.content.Intent
 import android.os.Handler
 import android.os.Looper
 import android.view.LayoutInflater
 import android.view.ViewGroup
-import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
 import androidx.navigation.fragment.findNavController
 import com.ssafy.gumi_life_project.R
-import com.ssafy.gumi_life_project.databinding.FragmentHomeBinding
 import com.ssafy.gumi_life_project.databinding.FragmentSplashBinding
-import com.ssafy.gumi_life_project.ui.main.MainActivity
 import com.ssafy.gumi_life_project.ui.main.MainViewModel
 import com.ssafy.gumi_life_project.util.template.BaseFragment
 import dagger.hilt.android.AndroidEntryPoint
@@ -19,7 +15,7 @@ import dagger.hilt.android.AndroidEntryPoint
 @AndroidEntryPoint
 class SplashFragment : BaseFragment<FragmentSplashBinding>(
     R.layout.fragment_splash
-)  {
+) {
     private val activityViewModel by activityViewModels<MainViewModel>()
 
     override fun onCreateBinding(

--- a/app/src/main/java/com/ssafy/gumi_life_project/ui/splash/SplashFragment.kt
+++ b/app/src/main/java/com/ssafy/gumi_life_project/ui/splash/SplashFragment.kt
@@ -1,24 +1,43 @@
 package com.ssafy.gumi_life_project.ui.splash
 
-
 import android.content.Intent
-import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.activityViewModels
+import androidx.navigation.fragment.findNavController
 import com.ssafy.gumi_life_project.R
-import com.ssafy.gumi_life_project.databinding.ActivitySplashBinding
+import com.ssafy.gumi_life_project.databinding.FragmentHomeBinding
+import com.ssafy.gumi_life_project.databinding.FragmentSplashBinding
 import com.ssafy.gumi_life_project.ui.main.MainActivity
-import com.ssafy.gumi_life_project.util.template.BaseActivity
+import com.ssafy.gumi_life_project.ui.main.MainViewModel
+import com.ssafy.gumi_life_project.util.template.BaseFragment
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
-class SplashActivity : BaseActivity<ActivitySplashBinding>(R.layout.activity_splash) {
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
+class SplashFragment : BaseFragment<FragmentSplashBinding>(
+    R.layout.fragment_splash
+)  {
+    private val activityViewModel by activityViewModels<MainViewModel>()
 
+    override fun onCreateBinding(
+        inflater: LayoutInflater,
+        container: ViewGroup?
+    ): FragmentSplashBinding {
+        return FragmentSplashBinding.inflate(inflater, container, false).apply {
+            lifecycleOwner = viewLifecycleOwner
+        }
+    }
+
+    override fun init() {
+        with(activityViewModel) {
+            getAllTipList()
+            getNowWeather()
+        }
         animateLoading()
-        moveToMainActivity()
-
+        moveToHomeFragment()
     }
 
     private fun animateLoading() {
@@ -26,11 +45,11 @@ class SplashActivity : BaseActivity<ActivitySplashBinding>(R.layout.activity_spl
         val runnable = object : Runnable {
             var currentImageViewIndex = 0
             val imageViews = listOf(
-                binding.imageviewSplash1,
-                binding.imageviewSplash2,
-                binding.imageviewSplash3,
-                binding.imageviewSplash4,
-                binding.imageviewSplash5
+                bindingNonNull.imageviewSplash1,
+                bindingNonNull.imageviewSplash2,
+                bindingNonNull.imageviewSplash3,
+                bindingNonNull.imageviewSplash4,
+                bindingNonNull.imageviewSplash5
             )
 
             override fun run() {
@@ -61,12 +80,11 @@ class SplashActivity : BaseActivity<ActivitySplashBinding>(R.layout.activity_spl
         handler.post(runnable)
     }
 
-    private fun moveToMainActivity() {
-        // 1초 후에 다른 Activity로 이동
+    private fun moveToHomeFragment() {
+        // 1.5초 후에 HomeFragment로 이동
         Handler(Looper.getMainLooper()).postDelayed({
-            intent = Intent(this, MainActivity::class.java)
-            startActivity(intent)
-            finish()
-        }, 1000)
+            findNavController().navigate(R.id.action_splashFragment_to_homeFragment)
+        }, 1500)
     }
+
 }

--- a/app/src/main/res/layout/bottom_sheet_tip.xml
+++ b/app/src/main/res/layout/bottom_sheet_tip.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+    </data>
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@drawable/rounded_top_corners"
+        android:padding="12dp"
+        android:orientation="vertical">
+
+        <TextView
+            android:id="@+id/textview_tip_subject"
+            style="@style/BottomSheetTitleTextStyle"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center"
+            android:textColor="@color/black"
+            android:text="@string/home_tip" />
+
+        <TextView
+            android:id="@+id/textview_tip_description"
+            style="@style/HomeMiddleContentGrayTextStyle"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="slkdfjlskdjflksd"
+            android:gravity="center"/>
+
+
+    </LinearLayout>
+</layout>

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -92,6 +92,7 @@
             </LinearLayout>
 
             <LinearLayout
+                android:id="@+id/linearlayout_tip"
                 android:layout_width="match_parent"
                 android:layout_height="64dp"
                 android:layout_marginTop="12dp"
@@ -101,19 +102,21 @@
                 android:paddingStart="18dp"
                 android:paddingEnd="18dp">
 
+
                 <TextView
                     android:id="@+id/textview_tip_title"
                     style="@style/HomeMiddleTitleTextStyle"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_weight="1"
+                    android:layout_weight="4"
                     android:text="@string/home_tip" />
 
                 <TextView
                     android:id="@+id/textview_tip_content"
                     style="@style/HomeMiddleContentTextStyle"
-                    android:layout_width="wrap_content"
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
+                    android:layout_weight="1"
                     android:text="마이구미는 맛있다." />
             </LinearLayout>
 

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -10,6 +10,10 @@
             type="com.ssafy.gumi_life_project.ui.home.HomeViewModel" />
 
         <variable
+            name="mainViewModel"
+            type="com.ssafy.gumi_life_project.ui.main.MainViewModel" />
+
+        <variable
             name="signalLight"
             type="com.ssafy.gumi_life_project.data.model.SignalLight" />
     </data>

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -47,8 +47,8 @@
 
                 <ImageView
                     android:id="@+id/imageview_today_weather_img"
-                    android:layout_width="48dp"
-                    android:layout_height="48dp"
+                    android:layout_width="44dp"
+                    android:layout_height="44dp"
                     android:layout_marginEnd="4dp"
                     android:src="@drawable/icon_rainy" />
 

--- a/app/src/main/res/layout/fragment_splash.xml
+++ b/app/src/main/res/layout/fragment_splash.xml
@@ -2,6 +2,9 @@
 <layout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools">
+    <data>
+
+    </data>
 
     <LinearLayout
         android:layout_width="match_parent"

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -3,7 +3,7 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/nav_graph"
-    app:startDestination="@id/homeFragment">
+    app:startDestination="@id/splashFragment">
 
     <fragment
         android:id="@+id/homeFragment"
@@ -17,4 +17,12 @@
         android:id="@+id/shuttleBusFragment"
         android:name="com.ssafy.gumi_life_project.ui.shuttlebus.ShuttleBusFragment"
         tools:layout="@layout/fragment_shuttle_bus" />
+    <fragment
+        android:id="@+id/splashFragment"
+        android:name="com.ssafy.gumi_life_project.ui.splash.SplashFragment"
+        android:label="SplashFragment" >
+        <action
+            android:id="@+id/action_splashFragment_to_homeFragment"
+            app:destination="@id/homeFragment" />
+    </fragment>
 </navigation>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -44,6 +44,12 @@
         <item name="android:fontFamily">@font/noto_sans_kr_medium</item>
     </style>
 
+    <style name="HomeMiddleContentGrayTextStyle">
+        <item name="android:textColor">#272727</item>
+        <item name="android:textSize">14sp</item>
+        <item name="android:fontFamily">@font/noto_sans_kr_medium</item>
+    </style>
+
 
     <style name="HomeWeatherTextStyle">
         <item name="android:textColor">#000000</item>


### PR DESCRIPTION
## Summary
스플래시, 홈 화면 구현 완료
## Describe your changes
- api 연결을 위한 ErrorResponse 데이터 클래스 추가, baseUrl 변경, manifest에 인터넷 권한 설정 추가
- Tip, WeatherResponse, Weather 데이터 클래스 추가
- 꿀팁 api 연결 (꿀팁 전체 목록을 가져오기)
- 오늘의 날씨 api 연결 (구미 인동의 현재 날씨를 가져오기)
- 홈 화면에 랜덤하게 꿀팁 타이틀을 보여주고, 클릭 시 바텀시트에 꿀팁의 설명을 보여줌
- 홈 화면에 오늘의 날씨를 보여주고, 현재 날씨에 따라 아이콘을 보여줌
- 기존의 스플래시 액티비티를 프래그먼트로 변경

## Issue number and link
#6 

## To Reviewers
홈 화면에 꿀팁과 오늘의 날씨를 보여주는 시간이 길기 때문에 기존의 스플래시 액티비티를 프래그먼트로 변경하고,
MainViewModel을 사용하여 스플래시 화면부터 api를 호출하도록 코드 수정하였습니다.
