### PR TITLE
[FEAT] 화면 상단 툴바 추가

### DIFF
--- a/app/src/main/res/drawable/tool_bar_shadow.xml
+++ b/app/src/main/res/drawable/tool_bar_shadow.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:shape="rectangle">
+    <gradient
+        android:angle="90"
+        android:endColor="#88D5D2D2"
+        android:startColor="@android:color/transparent" />
+</shape>

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -21,207 +21,217 @@
     <ScrollView
         android:id="@+id/scrollview_home"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
+        android:layout_height="match_parent"
         android:scrollbarStyle="outsideOverlay"
         android:scrollbars="vertical">
 
         <LinearLayout
-            android:id="@+id/linearlayout_home"
             android:layout_width="match_parent"
             android:layout_height="0dp"
-            android:orientation="vertical"
-            android:padding="20dp">
+            android:orientation="vertical">
+
+            <include layout="@layout/tool_bar_home" />
 
             <LinearLayout
-                android:layout_width="match_parent"
-                android:layout_height="64dp"
-                android:background="@drawable/border_main_background"
-                android:gravity="center"
-                android:orientation="horizontal"
-                android:paddingStart="18dp"
-                android:paddingEnd="18dp">
-
-                <TextView
-                    android:id="@+id/textview_today_weather_title"
-                    style="@style/HomeMiddleTitleTextStyle"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="1"
-                    android:text="@string/home_weather_today" />
-
-                <ImageView
-                    android:id="@+id/imageview_today_weather_img"
-                    android:layout_width="44dp"
-                    android:layout_height="44dp"
-                    android:layout_marginEnd="4dp"
-                    android:src="@drawable/icon_rainy" />
-
-                <TextView
-                    android:id="@+id/textview_today_weather_temperature"
-                    style="@style/HomeWeatherTextStyle"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:text="19º" />
-            </LinearLayout>
-
-            <LinearLayout
-                android:id="@+id/linearlayout_shuttle_bus"
-                android:layout_width="match_parent"
-                android:layout_height="64dp"
-                android:layout_marginTop="12dp"
-                android:background="@drawable/border_main_background"
-                android:gravity="center"
-                android:orientation="horizontal"
-                android:paddingStart="18dp">
-
-                <TextView
-                    android:id="@+id/textview_shuttle_time_title"
-                    style="@style/HomeMiddleTitleTextStyle"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="1"
-                    android:text="@string/home_shuttle_time" />
-
-                <TextView
-                    android:id="@+id/textview_shuttle_no_mark"
-                    style="@style/HomeMiddleContentTextStyle"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:visibility="gone"
-                    android:text="@string/home_shuttle_no_mark" />
-
-                <TextView
-                    android:id="@+id/textview_shuttle_bus_stop_name"
-                    style="@style/HomeMiddleContentTextStyle"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginRight="4dp"
-                    android:maxEms="6"
-                    android:maxLines="1"
-                    android:ellipsize="end"
-                    tools:text="구미역" />
-
-                <TextView
-                    android:id="@+id/textview_shuttle_bus_stop_time"
-                    style="@style/HomeMiddleContentTextStyle"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    tools:text="07:00" />
-
-                <ImageView
-                    android:id="@+id/imagebutton_home_to_shuttle"
-                    android:layout_width="48dp"
-                    android:layout_height="48dp"
-                    android:background="@drawable/icon_right" />
-            </LinearLayout>
-
-            <LinearLayout
-                android:id="@+id/linearlayout_tip"
-                android:layout_width="match_parent"
-                android:layout_height="64dp"
-                android:layout_marginTop="12dp"
-                android:background="@drawable/border_main_background"
-                android:gravity="center"
-                android:orientation="horizontal"
-                android:paddingStart="18dp"
-                android:paddingEnd="18dp">
-
-
-                <TextView
-                    android:id="@+id/textview_tip_title"
-                    style="@style/HomeMiddleTitleTextStyle"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="4"
-                    android:text="@string/home_tip" />
-
-                <TextView
-                    android:id="@+id/textview_tip_content"
-                    style="@style/HomeMiddleContentTextStyle"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="1"
-                    android:text="마이구미는 맛있다." />
-            </LinearLayout>
-
-            <LinearLayout
-                android:id="@+id/linearlayout_map"
+                android:id="@+id/linearlayout_home"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:orientation="vertical">
+                android:orientation="vertical"
+                android:padding="20dp">
 
                 <LinearLayout
                     android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:orientation="horizontal">
+                    android:layout_height="64dp"
+                    android:background="@drawable/border_main_background"
+                    android:gravity="center"
+                    android:orientation="horizontal"
+                    android:paddingStart="18dp"
+                    android:paddingEnd="18dp">
+
                     <TextView
-                        style="@style/LayoutTitleTextStyle"
-                        android:layout_width="0dp"
+                        android:id="@+id/textview_today_weather_title"
+                        style="@style/HomeMiddleTitleTextStyle"
+                        android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:layout_weight="1"
-                        android:layout_marginStart="7dp"
-                        android:text="@string/home_cross_walk" />
+                        android:text="@string/home_weather_today" />
 
                     <ImageView
-                        android:id="@+id/image_refresh"
-                        android:layout_width="40dp"
-                        android:layout_height="40dp"
-                        android:padding="5dp"
-                        android:onClick="@{() -> viewModel.loadAndSetTriggerTimes()}"
-                        android:layout_gravity="center"
-                        android:src="@drawable/baseline_refresh_24"/>
+                        android:id="@+id/imageview_today_weather_img"
+                        android:layout_width="44dp"
+                        android:layout_height="44dp"
+                        android:layout_marginEnd="4dp"
+                        android:src="@drawable/icon_rainy" />
+
+                    <TextView
+                        android:id="@+id/textview_today_weather_temperature"
+                        style="@style/HomeWeatherTextStyle"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:text="19º" />
                 </LinearLayout>
 
-
-                <androidx.constraintlayout.widget.ConstraintLayout
+                <LinearLayout
+                    android:id="@+id/linearlayout_shuttle_bus"
                     android:layout_width="match_parent"
-                    android:layout_height="300dp"
-                    android:background="@drawable/image_crosswalk">
+                    android:layout_height="64dp"
+                    android:layout_marginTop="12dp"
+                    android:background="@drawable/border_main_background"
+                    android:gravity="center"
+                    android:orientation="horizontal"
+                    android:paddingStart="18dp">
 
-                    <com.ssafy.gumi_life_project.ui.home.crosswalk.CrossWalkTimeView
-                        android:id="@+id/cross_walk_1"
+                    <TextView
+                        android:id="@+id/textview_shuttle_time_title"
+                        style="@style/HomeMiddleTitleTextStyle"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="@string/home_shuttle_time" />
+
+                    <TextView
+                        android:id="@+id/textview_shuttle_no_mark"
+                        style="@style/HomeMiddleContentTextStyle"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:onClick="@{() -> viewModel.onCrossWorkTimeViewClicked(signalLight.SIGNAL_LIGHT_1)}"
-                        app:layout_constraintBottom_toBottomOf="parent"
-                        app:layout_constraintEnd_toEndOf="parent"
-                        app:layout_constraintHorizontal_bias="0.058"
-                        app:layout_constraintStart_toStartOf="parent"
-                        app:layout_constraintTop_toTopOf="parent"
-                        app:layout_constraintVertical_bias="0.551"
-                        app:timeText="@{viewModel.timeText1.remainingTimeString}"
-                        app:timeColor="@{viewModel.timeText1.getCurrentColorRes()}"/>
+                        android:text="@string/home_shuttle_no_mark"
+                        android:visibility="gone" />
 
-                    <com.ssafy.gumi_life_project.ui.home.crosswalk.CrossWalkTimeView
-                        android:id="@+id/cross_walk_3"
+                    <TextView
+                        android:id="@+id/textview_shuttle_bus_stop_name"
+                        style="@style/HomeMiddleContentTextStyle"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:onClick="@{() -> viewModel.onCrossWorkTimeViewClicked(signalLight.SIGNAL_LIGHT_3)}"
-                        app:layout_constraintBottom_toBottomOf="parent"
-                        app:layout_constraintEnd_toEndOf="parent"
-                        app:layout_constraintHorizontal_bias="0.908"
-                        app:layout_constraintStart_toStartOf="parent"
-                        app:layout_constraintTop_toTopOf="parent"
-                        app:layout_constraintVertical_bias="0.502"
-                        app:timeText="@{viewModel.timeText3.remainingTimeString}"
-                        app:timeColor="@{viewModel.timeText3.getCurrentColorRes()}"/>
+                        android:layout_marginRight="4dp"
+                        android:ellipsize="end"
+                        android:maxEms="6"
+                        android:maxLines="1"
+                        tools:text="구미역" />
 
-                    <com.ssafy.gumi_life_project.ui.home.crosswalk.CrossWalkTimeView
-                        android:id="@+id/cross_work_2"
+                    <TextView
+                        android:id="@+id/textview_shuttle_bus_stop_time"
+                        style="@style/HomeMiddleContentTextStyle"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:onClick="@{() -> viewModel.onCrossWorkTimeViewClicked(signalLight.SIGNAL_LIGHT_2)}"
-                        app:layout_constraintBottom_toBottomOf="parent"
-                        app:layout_constraintEnd_toEndOf="parent"
-                        app:layout_constraintHorizontal_bias="0.466"
-                        app:layout_constraintStart_toStartOf="parent"
-                        app:layout_constraintTop_toTopOf="parent"
-                        app:layout_constraintVertical_bias="0.028"
-                        app:timeText="@{viewModel.timeText2.remainingTimeString}"
-                        app:timeColor="@{viewModel.timeText2.getCurrentColorRes()}"/>
+                        tools:text="07:00" />
 
-                </androidx.constraintlayout.widget.ConstraintLayout>
+                    <ImageView
+                        android:id="@+id/imagebutton_home_to_shuttle"
+                        android:layout_width="48dp"
+                        android:layout_height="48dp"
+                        android:background="@drawable/icon_right" />
+                </LinearLayout>
+
+                <LinearLayout
+                    android:id="@+id/linearlayout_tip"
+                    android:layout_width="match_parent"
+                    android:layout_height="64dp"
+                    android:layout_marginTop="12dp"
+                    android:background="@drawable/border_main_background"
+                    android:gravity="center"
+                    android:orientation="horizontal"
+                    android:paddingStart="18dp"
+                    android:paddingEnd="18dp">
+
+
+                    <TextView
+                        android:id="@+id/textview_tip_title"
+                        style="@style/HomeMiddleTitleTextStyle"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="4"
+                        android:text="@string/home_tip" />
+
+                    <TextView
+                        android:id="@+id/textview_tip_content"
+                        style="@style/HomeMiddleContentTextStyle"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"
+                        android:text="마이구미는 맛있다." />
+                </LinearLayout>
+
+                <LinearLayout
+                    android:id="@+id/linearlayout_map"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:orientation="vertical">
+
+                    <LinearLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:orientation="horizontal">
+
+                        <TextView
+                            style="@style/LayoutTitleTextStyle"
+                            android:layout_width="0dp"
+                            android:layout_height="wrap_content"
+                            android:layout_marginStart="7dp"
+                            android:layout_weight="1"
+                            android:text="@string/home_cross_walk" />
+
+                        <ImageView
+                            android:id="@+id/image_refresh"
+                            android:layout_width="40dp"
+                            android:layout_height="40dp"
+                            android:layout_gravity="center"
+                            android:onClick="@{() -> viewModel.loadAndSetTriggerTimes()}"
+                            android:padding="5dp"
+                            android:src="@drawable/baseline_refresh_24" />
+                    </LinearLayout>
+
+
+                    <androidx.constraintlayout.widget.ConstraintLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="300dp"
+                        android:background="@drawable/image_crosswalk">
+
+                        <com.ssafy.gumi_life_project.ui.home.crosswalk.CrossWalkTimeView
+                            android:id="@+id/cross_walk_1"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:onClick="@{() -> viewModel.onCrossWorkTimeViewClicked(signalLight.SIGNAL_LIGHT_1)}"
+                            app:layout_constraintBottom_toBottomOf="parent"
+                            app:layout_constraintEnd_toEndOf="parent"
+                            app:layout_constraintHorizontal_bias="0.058"
+                            app:layout_constraintStart_toStartOf="parent"
+                            app:layout_constraintTop_toTopOf="parent"
+                            app:layout_constraintVertical_bias="0.551"
+                            app:timeColor="@{viewModel.timeText1.getCurrentColorRes()}"
+                            app:timeText="@{viewModel.timeText1.remainingTimeString}" />
+
+                        <com.ssafy.gumi_life_project.ui.home.crosswalk.CrossWalkTimeView
+                            android:id="@+id/cross_walk_3"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:onClick="@{() -> viewModel.onCrossWorkTimeViewClicked(signalLight.SIGNAL_LIGHT_3)}"
+                            app:layout_constraintBottom_toBottomOf="parent"
+                            app:layout_constraintEnd_toEndOf="parent"
+                            app:layout_constraintHorizontal_bias="0.908"
+                            app:layout_constraintStart_toStartOf="parent"
+                            app:layout_constraintTop_toTopOf="parent"
+                            app:layout_constraintVertical_bias="0.502"
+                            app:timeColor="@{viewModel.timeText3.getCurrentColorRes()}"
+                            app:timeText="@{viewModel.timeText3.remainingTimeString}" />
+
+                        <com.ssafy.gumi_life_project.ui.home.crosswalk.CrossWalkTimeView
+                            android:id="@+id/cross_work_2"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:onClick="@{() -> viewModel.onCrossWorkTimeViewClicked(signalLight.SIGNAL_LIGHT_2)}"
+                            app:layout_constraintBottom_toBottomOf="parent"
+                            app:layout_constraintEnd_toEndOf="parent"
+                            app:layout_constraintHorizontal_bias="0.466"
+                            app:layout_constraintStart_toStartOf="parent"
+                            app:layout_constraintTop_toTopOf="parent"
+                            app:layout_constraintVertical_bias="0.028"
+                            app:timeColor="@{viewModel.timeText2.getCurrentColorRes()}"
+                            app:timeText="@{viewModel.timeText2.remainingTimeString}" />
+
+                    </androidx.constraintlayout.widget.ConstraintLayout>
+                </LinearLayout>
             </LinearLayout>
         </LinearLayout>
+
     </ScrollView>
 </layout>

--- a/app/src/main/res/layout/tool_bar_back_button.xml
+++ b/app/src/main/res/layout/tool_bar_back_button.xml
@@ -3,7 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/tool_bar_back_button"
     android:layout_width="match_parent"
-    android:layout_height="55dp">
+    android:layout_height="70dp">
 
     <ImageView
         android:id="@+id/button_go_back"

--- a/app/src/main/res/layout/tool_bar_home.xml
+++ b/app/src/main/res/layout/tool_bar_home.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.appcompat.widget.Toolbar xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="70dp"
+    app:contentInsetStart="0dp">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical">
+
+        <TextView
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            style="@style/HomeToolBarSubTitleTextStyle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginLeft="20dp"
+            android:layout_marginTop="6dp"
+            android:text="@string/home_subtitle" />
+
+        <TextView
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            android:layout_marginTop="20dp"
+            style="@style/HomeToolBarTitleTextStyle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginLeft="20dp"
+            android:text="@string/home_tool_bar_title" />
+
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="4dp"
+            android:background="@drawable/tool_bar_shadow"
+            app:layout_constraintBottom_toBottomOf="parent" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</androidx.appcompat.widget.Toolbar>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -14,6 +14,8 @@
     <string name="home_tip">꿀팁</string>
     <string name="home_next_time">다음 시간</string>
     <string name="home_shuttle_no_mark">즐겨찾기 된 셔틀이 없습니다.</string>
+    <string name="home_tool_bar_sub_title">10기를 위한 싸피 가이드</string>
+    <string name="home_tool_bar_title">구미 캠퍼스</string>
 
     <!-- cross work -->
     <string name="cross_walk_title1">1번 신호등</string>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -106,4 +106,16 @@
         <item name="android:textSize">15sp</item>
         <item name="android:fontFamily">@font/noto_sans_kr_black</item>
     </style>
+
+    <style name="HomeToolBarSubTitleTextStyle">
+        <item name="android:textColor">@color/black</item>
+        <item name="android:textSize">10sp</item>
+        <item name="android:fontFamily">@font/noto_sans_kr_light</item>
+    </style>
+
+    <style name="HomeToolBarTitleTextStyle">
+        <item name="android:textColor">@color/black</item>
+        <item name="android:textSize">15sp</item>
+        <item name="android:fontFamily">@font/noto_sans_kr_black</item>
+    </style>
 </resources>


### PR DESCRIPTION
## Summary
홈 화면과 셔틀버스 정보 화면 상단에 툴바 추가

## Describe your changes
* 홈 화면 상단 툴바 추가
* 셔틀버스 화면 상단 툴바 크기 조정
* 툴바에 사용할 그림자 추가
* 툴바에 사용할 문자열, 스타일 추가

## Issue number and link
#5 #6

## To Reviewers
피그마에 있는 대로 홈 화면의 툴바에만 그림자를 추가하였는데 셔틀버스 화면의 툴바에도 그림자가 필요할지 고민입니다. 
