### PR TITLE
[FEAT] 게시글 수정 기능

### DIFF
--- a/app/src/main/java/com/ssafy/gumi_life_project/data/model/BoardItem.kt
+++ b/app/src/main/java/com/ssafy/gumi_life_project/data/model/BoardItem.kt
@@ -26,3 +26,7 @@ data class BoardDetailResponse(
     val comments: List<Comment>,
     val message: String
 )
+
+data class BoardModifyResponse(
+    val message: String
+)

--- a/app/src/main/java/com/ssafy/gumi_life_project/data/model/BoardItem.kt
+++ b/app/src/main/java/com/ssafy/gumi_life_project/data/model/BoardItem.kt
@@ -7,9 +7,9 @@ data class BoardItem(
     val hit: Int,
     val createDate: String,
     val updateDate: String?,
-    val folder: String,
-    val originName: String,
-    val saveName: String,
+    val folder: String?,
+    val originName: String?,
+    val saveName: String?,
     val writerId: Int,
     val writerName: String,
     val likesNum: Int,
@@ -30,3 +30,7 @@ data class BoardDetailResponse(
 data class BoardModifyResponse(
     val message: String
 )
+
+enum class BoardModifyResponseType {
+    SUCCESS, FAIL
+}

--- a/app/src/main/java/com/ssafy/gumi_life_project/data/remote/ApiService.kt
+++ b/app/src/main/java/com/ssafy/gumi_life_project/data/remote/ApiService.kt
@@ -41,6 +41,7 @@ interface ApiService {
     @PUT("/board/deleteComment")
     suspend fun deleteComment(): NetworkResponse<CommentResponse, ErrorResponse>
 
+    @Multipart
     @PUT("/board/modifyBoard")
     suspend fun modifyBoard(
         @Part("boardDto") boardDto: RequestBody,

--- a/app/src/main/java/com/ssafy/gumi_life_project/data/remote/ApiService.kt
+++ b/app/src/main/java/com/ssafy/gumi_life_project/data/remote/ApiService.kt
@@ -40,4 +40,10 @@ interface ApiService {
 
     @PUT("/board/deleteComment")
     suspend fun deleteComment(): NetworkResponse<CommentResponse, ErrorResponse>
+
+    @PUT("/board/modifyBoard")
+    suspend fun modifyBoard(
+        @Part("boardDto") boardDto: RequestBody,
+        @Part files: MutableList<MultipartBody.Part>?
+    ): NetworkResponse<BoardModifyResponse, ErrorResponse>
 }

--- a/app/src/main/java/com/ssafy/gumi_life_project/data/repository/board/BoardRepository.kt
+++ b/app/src/main/java/com/ssafy/gumi_life_project/data/repository/board/BoardRepository.kt
@@ -16,4 +16,9 @@ interface BoardRepository {
         files: MutableList<MultipartBody.Part>?
     ): NetworkResponse<BoardWriteResponse, ErrorResponse>
 
+    suspend fun modifyBoard(
+        boardDto: RequestBody,
+        files: MutableList<MultipartBody.Part>?
+    ): NetworkResponse<BoardModifyResponse, ErrorResponse>
+
 }

--- a/app/src/main/java/com/ssafy/gumi_life_project/data/repository/board/BoardRepositoryImpl.kt
+++ b/app/src/main/java/com/ssafy/gumi_life_project/data/repository/board/BoardRepositoryImpl.kt
@@ -31,4 +31,11 @@ class BoardRepositoryImpl @Inject constructor(
 
     }
 
+    override suspend fun modifyBoard(
+        boardDto: RequestBody,
+        files: MutableList<MultipartBody.Part>?
+    ): NetworkResponse<BoardModifyResponse, ErrorResponse> {
+        return apiService.modifyBoard(boardDto, files)
+    }
+
 }

--- a/app/src/main/java/com/ssafy/gumi_life_project/ui/board/BoardDetailFragment.kt
+++ b/app/src/main/java/com/ssafy/gumi_life_project/ui/board/BoardDetailFragment.kt
@@ -69,7 +69,7 @@ class BoardDetailFragment : BaseFragment<FragmentBoardDetailBinding>(
                         true
                     }
                     R.id.button_board_update -> {
-                        // Handle menu item 2 click
+                        findNavController().navigate(R.id.action_boardDetailFragment_to_boardModifyFragment)
                         true
                     }
                     else -> false

--- a/app/src/main/java/com/ssafy/gumi_life_project/ui/board/BoardModifyFragment.kt
+++ b/app/src/main/java/com/ssafy/gumi_life_project/ui/board/BoardModifyFragment.kt
@@ -5,49 +5,62 @@ import android.view.ViewGroup
 import androidx.fragment.app.activityViewModels
 import androidx.navigation.fragment.findNavController
 import com.ssafy.gumi_life_project.R
-import com.ssafy.gumi_life_project.data.model.BoardWriteItem
-import com.ssafy.gumi_life_project.databinding.FragmentBoardWriteBinding
+import com.ssafy.gumi_life_project.data.model.BoardModifyResponseType
+import com.ssafy.gumi_life_project.databinding.FragmentBoardModifyBinding
 import com.ssafy.gumi_life_project.util.template.BaseFragment
 
-class BoardModifyFragment : BaseFragment<FragmentBoardWriteBinding>(
-    R.layout.fragment_board_write
+class BoardModifyFragment : BaseFragment<FragmentBoardModifyBinding>(
+    R.layout.fragment_board_modify
 ) {
     private val viewModel by activityViewModels<BoardViewModel>()
-
     override fun onCreateBinding(
         inflater: LayoutInflater,
         container: ViewGroup?
-    ): FragmentBoardWriteBinding {
-        return FragmentBoardWriteBinding.inflate(inflater, container, false).apply {
+    ): FragmentBoardModifyBinding {
+        return FragmentBoardModifyBinding.inflate(inflater, container, false).apply {
             lifecycleOwner = viewLifecycleOwner
             viewModel = this@BoardModifyFragment.viewModel
         }
     }
 
+
     override fun init() {
         initToolbar()
         initListener()
+        initObserver()
     }
 
     private fun initToolbar() {
-        bindingNonNull.toolbarBoardWrite.toolbarBackButtonTitle.text =
+        bindingNonNull.toolbarBoardModify.toolbarBackButtonTitle.text =
             resources.getString(R.string.board_modify_toolbar_title)
-        bindingNonNull.toolbarBoardWrite.buttonGoBack.setOnClickListener {
+        bindingNonNull.toolbarBoardModify.buttonGoBack.setOnClickListener {
             findNavController().navigate(R.id.action_boardModifyFragment_to_boardDetailFragment)
         }
     }
 
     private fun initListener() {
-        bindingNonNull.buttonWrite.setOnClickListener {
-            val title = bindingNonNull.edittextTitle.text.toString()
-            val content = bindingNonNull.edittextContent.text.toString()
+        bindingNonNull.buttonModify.setOnClickListener {
+            val title = bindingNonNull.edittextModifyTitle.text.toString()
+            val content = bindingNonNull.edittextModifyContent.text.toString()
             if (title != "" && content != "") {
-                viewModel.writeBoard(BoardWriteItem(title, content))
+                viewModel.modifyBoard(title, content)
             } else {
                 showToast(getString(R.string.board_write_toast_message))
             }
         }
     }
 
+    private fun initObserver() {
+        viewModel.modifyResponse.observe(viewLifecycleOwner) { event ->
+            event.getContentIfNotHandled()?.let {
+                if (it == BoardModifyResponseType.SUCCESS) {
+                    showToast(getString(R.string.board_modify_response_success))
+                } else if (it == BoardModifyResponseType.FAIL) {
+                    showToast(getString(R.string.board_modify_response_fail))
+                }
+                findNavController().navigate(R.id.action_boardModifyFragment_to_boardDetailFragment)
+            }
+        }
+    }
 
 }

--- a/app/src/main/java/com/ssafy/gumi_life_project/ui/board/BoardModifyFragment.kt
+++ b/app/src/main/java/com/ssafy/gumi_life_project/ui/board/BoardModifyFragment.kt
@@ -1,0 +1,53 @@
+package com.ssafy.gumi_life_project.ui.board
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.fragment.app.activityViewModels
+import androidx.navigation.fragment.findNavController
+import com.ssafy.gumi_life_project.R
+import com.ssafy.gumi_life_project.data.model.BoardWriteItem
+import com.ssafy.gumi_life_project.databinding.FragmentBoardWriteBinding
+import com.ssafy.gumi_life_project.util.template.BaseFragment
+
+class BoardModifyFragment : BaseFragment<FragmentBoardWriteBinding>(
+    R.layout.fragment_board_write
+) {
+    private val viewModel by activityViewModels<BoardViewModel>()
+
+    override fun onCreateBinding(
+        inflater: LayoutInflater,
+        container: ViewGroup?
+    ): FragmentBoardWriteBinding {
+        return FragmentBoardWriteBinding.inflate(inflater, container, false).apply {
+            lifecycleOwner = viewLifecycleOwner
+            viewModel = this@BoardModifyFragment.viewModel
+        }
+    }
+
+    override fun init() {
+        initToolbar()
+        initListener()
+    }
+
+    private fun initToolbar() {
+        bindingNonNull.toolbarBoardWrite.toolbarBackButtonTitle.text =
+            resources.getString(R.string.board_modify_toolbar_title)
+        bindingNonNull.toolbarBoardWrite.buttonGoBack.setOnClickListener {
+            findNavController().navigate(R.id.action_boardModifyFragment_to_boardDetailFragment)
+        }
+    }
+
+    private fun initListener() {
+        bindingNonNull.buttonWrite.setOnClickListener {
+            val title = bindingNonNull.edittextTitle.text.toString()
+            val content = bindingNonNull.edittextContent.text.toString()
+            if (title != "" && content != "") {
+                viewModel.writeBoard(BoardWriteItem(title, content))
+            } else {
+                showToast(getString(R.string.board_write_toast_message))
+            }
+        }
+    }
+
+
+}

--- a/app/src/main/res/layout/fragment_board_modify.xml
+++ b/app/src/main/res/layout/fragment_board_modify.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <data>
+
+        <variable
+            name="viewModel"
+            type="com.ssafy.gumi_life_project.ui.board.BoardViewModel" />
+    </data>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <include
+            android:id="@+id/toolbar_board_modify"
+            layout="@layout/toolbar_back_button" />
+
+        <androidx.appcompat.widget.AppCompatButton
+            android:id="@+id/button_modify"
+            style="@style/BoardWriteButtonTextStyle"
+            android:layout_width="60dp"
+            android:layout_height="40dp"
+            android:background="@drawable/button_rounded_radius30"
+            android:text="@string/board_write_button_finish"
+            app:layout_constraintBottom_toBottomOf="@+id/toolbar_board_modify"
+            app:layout_constraintEnd_toEndOf="@+id/toolbar_board_modify"
+            app:layout_constraintHorizontal_bias="0.93"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_margin="20dp"
+            android:layout_marginStart="20dp"
+            android:layout_marginTop="656dp"
+            android:layout_marginEnd="20dp"
+            android:layout_marginBottom="656dp"
+            android:orientation="vertical"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/toolbar_board_modify"
+            app:layout_constraintVertical_bias="0.0">
+
+            <EditText
+                android:id="@+id/edittext_modify_title"
+                style="@style/BoardWriteTitleHintTextStyle"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:background="@null"
+                android:hint="@string/board_write_textview_title_hint"
+                android:text="@{viewModel.boardDetail.boardDetail.title}" />
+
+            <View
+                android:layout_width="match_parent"
+                android:layout_height="1dp"
+                android:background="@color/line_gray" />
+
+            <EditText
+                android:id="@+id/edittext_modify_content"
+                style="@style/BoardWriteContentHintTextStyle"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginBottom="10dp"
+                android:background="@null"
+                android:hint="@string/board_write_textview_content_hint"
+                android:text="@{viewModel.boardDetail.boardDetail.content}" />
+        </LinearLayout>
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -61,6 +61,9 @@
             app:destination="@id/boardListFragment"
             app:popUpTo="@id/boardListFragment"
             app:popUpToInclusive="true" />
+        <action
+            android:id="@+id/action_boardDetailFragment_to_boardModifyFragment"
+            app:destination="@id/boardModifyFragment" />
     </fragment>
     <fragment
         android:id="@+id/boardWriteFragment"
@@ -70,6 +73,16 @@
             android:id="@+id/action_boardWriteFragment_to_boardListFragment"
             app:destination="@id/boardListFragment"
             app:popUpTo="@id/boardListFragment"
+            app:popUpToInclusive="true" />
+    </fragment>
+    <fragment
+        android:id="@+id/boardModifyFragment"
+        android:name="com.ssafy.gumi_life_project.ui.board.BoardModifyFragment"
+        android:label="BoardModifyFragment" >
+        <action
+            android:id="@+id/action_boardModifyFragment_to_boardDetailFragment"
+            app:destination="@id/boardDetailFragment"
+            app:popUpTo="@id/boardDetailFragment"
             app:popUpToInclusive="true" />
     </fragment>
 </navigation>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -51,4 +51,7 @@
     <string name="board_write_image_process_fail">이미지 처리에 실패했습니다.</string>
     <string name="board_write_response_fail">게시글 작성에 실패했습니다. 다시 시도해주세요.</string>
     <string name="board_write_response_success">게시글이 작성되었습니다.</string>
+    <string name="board_modify_toolbar_title">글수정</string>
+    <string name="board_modify_response_fail">게시글 수정에 실패했습니다. 다시 시도해주세요.</string>
+    <string name="board_modify_response_success">게시글이 수정되었습니다.</string>
 </resources>


### PR DESCRIPTION
## Summary
게시글 수정 기능 추가

## Describe your changes
* 게시글 수정 화면 레이아웃 추가
* 게시글 수정에 필요한 서버 통신 관련 코드 작성
* 게시글 수정 화면에 필요한 문자열 추가
* 게시글 수정에 필요한 클래스 추가
* 게시글 수정 화면에서 게시글 리스트로, 게시글 리스트에서 게시글 수정 화면으로 이동하는 네비게이션 액션 추가

## Issue number and link
#34 

## To Reviewers
게시글 작성 화면과 게시글 수정 화면이 완전히 똑같이 생겼습니다
그래서 게시글 작성 화면을 재사용 하려고 했으나 데이터 바인딩으로 게시글 상세에 있던 내용을 게시글 수정에서 보여주려고 하다 보니 게시글 수정 레이아웃을 새로 만들어야 했습니다.
이 문제에 대해서 어떻게 생각하시는지 리뷰 남겨주시면 감사하겠습니다.